### PR TITLE
Fix capitalization in makefiles to match repo path names

### DIFF
--- a/Portable/board_DevEBoxH7/Makefile
+++ b/Portable/board_DevEBoxH7/Makefile
@@ -36,25 +36,25 @@ BUILD_DIR = build
 ######################################
 # C sources
 C_SOURCES =  \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_cortex.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_dma.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_dma_ex.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_fdcan.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_flash.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_flash_ex.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_gpio.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_pcd.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_pcd_ex.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_pwr.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_pwr_ex.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_rcc.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_rcc_ex.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_tim.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_tim_ex.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_uart.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_uart_ex.c \
-../../Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_usb.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_cortex.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_dma.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_dma_ex.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_fdcan.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_flash.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_flash_ex.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_gpio.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_pcd.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_pcd_ex.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_pwr.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_pwr_ex.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_rcc.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_rcc_ex.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_tim.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_tim_ex.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_uart.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_hal_uart_ex.c \
+../../Drivers/stm32h7xx_hal_driver/Src/stm32h7xx_ll_usb.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c \
@@ -140,10 +140,10 @@ AS_INCLUDES =
 C_INCLUDES =  \
 -IInc \
 -I../../Core/Inc \
--I../../Drivers/STM32H7xx_HAL_Driver/Inc \
--I../../Drivers/STM32H7xx_HAL_Driver/Inc \
--I../../Drivers/STM32H7xx_HAL_Driver/Inc/Legacy \
--I../../Drivers/CMSIS_DEVICE_H7/Include \
+-I../../Drivers/stm32h7xx_hal_driver/Inc \
+-I../../Drivers/stm32h7xx_hal_driver/Inc \
+-I../../Drivers/stm32h7xx_hal_driver/Inc/Legacy \
+-I../../Drivers/cmsis_device_h7/Include \
 -I../../Drivers/CMSIS/Include \
 -I../../Middlewares/ST/STM32_USB_Device_Library/Core/Inc \
 -I../../Middlewares/Third_Party/FreeRTOS/include \

--- a/Portable/board_budgetcan_g0/Makefile
+++ b/Portable/board_budgetcan_g0/Makefile
@@ -36,25 +36,25 @@ BUILD_DIR = build
 ######################################
 # C sources
 C_SOURCES =  \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_cortex.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_dma.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_dma_ex.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_fdcan.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_flash.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_flash_ex.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_gpio.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_pcd.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_pcd_ex.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_pwr.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_pwr_ex.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_rcc.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_rcc_ex.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_tim.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_tim_ex.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_uart.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_hal_uart_ex.c \
-../../Drivers/STM32G0xx_HAL_Driver/Src/stm32g0xx_ll_usb.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_cortex.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_dma.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_dma_ex.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_fdcan.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_flash.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_flash_ex.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_gpio.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_pcd.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_pcd_ex.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_pwr.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_pwr_ex.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_rcc.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_rcc_ex.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_tim.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_tim_ex.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_hal_uart_ex.c \
+../../Drivers/stm32g0xx_hal_driver/Src/stm32g0xx_ll_usb.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c \
@@ -139,10 +139,10 @@ AS_INCLUDES =
 C_INCLUDES =  \
 -IInc \
 -I../../Core/Inc \
--I../../Drivers/STM32G0xx_HAL_Driver/Inc \
--I../../Drivers/STM32G0xx_HAL_Driver/Inc \
--I../../Drivers/STM32G0xx_HAL_Driver/Inc/Legacy \
--I../../Drivers/CMSIS_DEVICE_G0/Include \
+-I../../Drivers/stm32g0xx_hal_driver/Inc \
+-I../../Drivers/stm32g0xx_hal_driver/Inc \
+-I../../Drivers/stm32g0xx_hal_driver/Inc/Legacy \
+-I../../Drivers/cmsis_device_g0/Include \
 -I../../Drivers/CMSIS/Include \
 -I../../Middlewares/ST/STM32_USB_Device_Library/Core/Inc \
 -I../../Middlewares/Third_Party/FreeRTOS/include \

--- a/Portable/board_canablev1/Makefile
+++ b/Portable/board_canablev1/Makefile
@@ -36,22 +36,22 @@ BUILD_DIR = build
 ######################################
 # C sources
 C_SOURCES =  \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_cortex.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_can.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_dma.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_flash.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_flash_ex.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_gpio.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_pcd.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_pcd_ex.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_pwr.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_pwr_ex.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_rcc.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_rcc_ex.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_tim.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_tim_ex.c \
-../../Drivers/STM32F0xx_HAL_Driver/Src/stm32f0xx_ll_usb.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_cortex.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_can.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_dma.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_flash.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_flash_ex.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_gpio.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_pcd.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_pcd_ex.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_pwr.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_pwr_ex.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_rcc.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_rcc_ex.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_tim.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_hal_tim_ex.c \
+../../Drivers/stm32f0xx_hal_driver/Src/stm32f0xx_ll_usb.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c \
@@ -135,9 +135,9 @@ C_INCLUDES =  \
 -I../../Core/Inc \
 -I../../Portable/board_canablev1/Inc \
 -I../../Drivers/CMSIS/Include \
--I../../Drivers/STM32F0xx_HAL_Driver/Inc \
--I../../Drivers/STM32F0xx_HAL_Driver/Inc/Legacy \
--I../../Drivers/CMSIS_DEVICE_F0/Include \
+-I../../Drivers/stm32f0xx_hal_driver/Inc \
+-I../../Drivers/stm32f0xx_hal_driver/Inc/Legacy \
+-I../../Drivers/cmsis_device_f0/Include \
 -I../../Drivers/CMSIS/Include \
 -I../../Middlewares/ST/STM32_USB_Device_Library/Core/Inc \
 -I../../Middlewares/Third_Party/FreeRTOS/include \

--- a/Portable/board_canablev2/Makefile
+++ b/Portable/board_canablev2/Makefile
@@ -36,24 +36,24 @@ BUILD_DIR = build
 ######################################
 # C sources
 C_SOURCES =  \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_cortex.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_dma.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_dma_ex.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_fdcan.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_flash.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_flash_ex.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_flash_ramfunc.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_gpio.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_pcd.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_pcd_ex.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_pwr.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_pwr_ex.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_rcc.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_rcc_ex.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_tim.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_tim_ex.c \
-../../Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_usb.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_cortex.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_dma.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_dma_ex.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_fdcan.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_flash.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_flash_ex.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_flash_ramfunc.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_gpio.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_pcd.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_pcd_ex.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_pwr.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_pwr_ex.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_rcc.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_rcc_ex.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_tim.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_hal_tim_ex.c \
+../../Drivers/stm32g4xx_hal_driver/Src/stm32g4xx_ll_usb.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c \
 ../../Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ioreq.c \
@@ -138,9 +138,9 @@ C_INCLUDES =  \
 -I../../Core/Inc \
 -I../../Portable/board_canablev2/Inc \
 -I../../Drivers/CMSIS/Include \
--I../../Drivers/STM32G4xx_HAL_Driver/Inc \
--I../../Drivers/STM32G4xx_HAL_Driver/Inc/Legacy \
--I../../Drivers/CMSIS_DEVICE_G4/Include \
+-I../../Drivers/stm32g4xx_hal_driver/Inc \
+-I../../Drivers/stm32g4xx_hal_driver/Inc/Legacy \
+-I../../Drivers/cmsis_device_g4/Include \
 -I../../Drivers/CMSIS/Include \
 -I../../Middlewares/ST/STM32_USB_Device_Library/Core/Inc \
 -I../../Middlewares/Third_Party/FreeRTOS/include \
@@ -164,7 +164,7 @@ CFLAGS += -MMD -MP -MF"$(@:%.o=%.d)"
 # LDFLAGS
 #######################################
 # link script
-LDSCRIPT = STM32G431C6Tx_FLASH.ld
+LDSCRIPT = STM32G431C6TX_FLASH.ld
 
 # libraries
 LIBS = -lc -lm -lnosys 


### PR DESCRIPTION
Fixes issue where fresh clone wouldn't compile on a case sensitive operating system due to Makefile-referenced paths not matching capitalization of paths in repo.