### PR TITLE
fix linker error

### DIFF
--- a/Core/Inc/usbd_gs_can.h
+++ b/Core/Inc/usbd_gs_can.h
@@ -93,6 +93,7 @@ bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqType
 bool USBD_GS_CAN_CustomInterfaceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);
 bool USBD_GS_CAN_DfuDetachRequested(USBD_HandleTypeDef *pdev);
 uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_frame *frame);
+uint8_t USBD_GS_CAN_PrepareReceive(USBD_HandleTypeDef *pdev);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi,
while trying to compile the firmware I ran into a linker error:

```
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: build/usbd_gs_can.o: in function `USBD_GS_CAN_DataOut':
/budgetcan_fw/Portable/board_budgetcan_g0/../../Core/Src/usbd_gs_can.c:554: undefined reference to `USBD_GS_CAN_PrepareReceive'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: /budgetcan_fw/Portable/board_budgetcan_g0/../../Core/Src/usbd_gs_can.c:548: undefined reference to `USBD_GS_CAN_PrepareReceive'
/usr/lib/gcc/arm-none-eabi/12.2.1/../../../arm-none-eabi/bin/ld: build/usbd_gs_can.o: in function `USBD_GS_CAN_Start':
/budgetcan_fw/Portable/board_budgetcan_g0/../../Core/Src/usbd_gs_can.c:300: undefined reference to `USBD_GS_CAN_PrepareReceive'
collect2: error: ld returned 1 exit status
make: *** [Makefile:197: build/budgetcan_g0_fw.elf] Fout 1
```

This was caused by a missing reference in a header file. Adding the missing prototype fixed the issue for me.

